### PR TITLE
Fix check for existing Exchange server

### DIFF
--- a/Install-Exchange15.ps1
+++ b/Install-Exchange15.ps1
@@ -1602,7 +1602,7 @@ process {
             }
         }
         If ( $State['InstallMDBDBPath']) {
-            $Location= Split-Path $State['InstallMDBLogPath'] -Qualifier
+            $Location= Split-Path $State['InstallMDBDBPath'] -Qualifier
             Write-MyOutput 'Checking MDB database path ..'
             If( !(Test-Path $Location)) {
                 Write-MyError "MDB database location unavailable: ($Location)"

--- a/Install-Exchange15.ps1
+++ b/Install-Exchange15.ps1
@@ -932,12 +932,15 @@ process {
         }
     }
 
-   Function Test-ExistingExchangeServer( [string]$Name) {
-        $NC= Get-RootNC
+    Function Test-ExistingExchangeServer( [string]$Name) {
+        $DE = New-Object System.DirectoryServices.DirectoryEntry
+        $Configuration = (($DE.Properties["objectCategory"]).ToString())
+        $index = $Configuration.IndexOf('CN=Configuration')
+        $Configuration = $Configuration.Substring($index)
         $LDAPSearch= New-Object System.DirectoryServices.DirectorySearcher
-        $LDAPSearch.SearchRoot= "LDAP://CN=Configuration,$NC"
-        $LDAPSearch.Filter= "(&(cn=$Name)(objectClass=msExchExchangeServer))"
-        $Results= $LDAPSearch.FindAll()
+        $LDAPSearch.SearchRoot = "LDAP://$Configuration"
+        $LDAPSearch.Filter = "(&(cn=$Name)(objectClass=msExchExchangeServer))"
+        $Results = $LDAPSearch.FindAll()
         Return ($Results.Count -gt 0)
     }
 
@@ -1008,7 +1011,7 @@ process {
                     }
                     Else {
                        $roles+= 'ClientAccess'
-                    } 
+                    }
                 }
 	        $RolesParm= $roles -Join ','
                 $Params= '/mode:install', "/roles:$RolesParm", '/IAcceptExchangeServerLicenseTerms', '/DoNotStartTransport', '/InstallWindowsComponents'
@@ -1830,14 +1833,14 @@ process {
         }
 
         $Locations= @(
-            "$SystemRoot|Cluster", 
+            "$SystemRoot|Cluster",
             "$InstallFolder|ClientAccess\OAB,FIP-FS,GroupMetrics,Logging,Mailbox",
             "$InstallFolder\TransportRoles\Data|IpFilter,Queue,SenderReputation,Temp",
             "$InstallFolder\TransportRoles|Logs,Pickup,Replay",
-            "$InstallFolder\UnifiedMessaging|Grammars,Prompts,Temp,VoiceMail", 
-            "$InstallFolder|Working\OleConverter", 
+            "$InstallFolder\UnifiedMessaging|Grammars,Prompts,Temp,VoiceMail",
+            "$InstallFolder|Working\OleConverter",
             "$SystemRoot\Microsoft.NET\Framework64\v4.0.30319|Temporary ASP.NET Files",
-            "$SystemDrive\InetPub\Temp|IIS Temporary Compressed Files", 
+            "$SystemDrive\InetPub\Temp|IIS Temporary Compressed Files",
             "$SystemRoot|System32\InetSrv",
             "$SystemDrive|Temp\OICE_*"
         )

--- a/Install-Exchange15.ps1
+++ b/Install-Exchange15.ps1
@@ -1564,7 +1564,7 @@ process {
             }
         }
 
-        If( ( Test-ExistingExchangeServer $env:computerName) -and ($State["InstallPhase"] -eq 0)) {
+        If( ( Test-ExistingExchangeServer $env:computerName)) { # -and ($State["InstallPhase"] -eq 0) : Never will come
             If( $State['Recover']) {
                 Write-MyOutput 'Recovery mode specified, Exchange server object found'
             }


### PR DESCRIPTION
I'm use your script for install Exchange 2016 at child domain (child.root.com).
This code:

$NC= Get-RootNC
$LDAPSearch= New-Object System.DirectoryServices.DirectorySearcher
$LDAPSearch.SearchRoot= "LDAP://CN=Configuration,$NC"

produce error because $NC is "DC=child,DC=root,DC=com" and SearchRoot "LDAP://CN=Configuration,DC=child,DC=root,DC=com" is wrong.

Correct value for SearchRoot: "LDAP://CN=Configuration,DC=root,DC=com"
