### PR TITLE
With reboot pending, the phase auto increment & step are being skipped.

### DIFF
--- a/Install-Exchange15.ps1
+++ b/Install-Exchange15.ps1
@@ -2291,6 +2291,7 @@ process {
 
     Write-MyOutput "Checking for pending reboot .."
     If( is-RebootPending ) {
+        $State["InstallPhase"]--
         If( $State["AutoPilot"]) {
             Write-MyWarning "Reboot pending, will reboot system and rerun phase"
         }


### PR DESCRIPTION
If a reboot is pending, the InstallPhase auto increment at the beginning and then save as LastSuccessfulPhase step. 
Next reboot the last step is reloaded and incremented again resulting in step being skipped. 